### PR TITLE
feat: Allow usage with both beets 1.x and 2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -eux; \
 
 RUN python3 -m pip install \
 		ytmusicapi==1.9.0 \
-		yt-dlp==2024.12.13
+		yt-dlp[default]==2026.6.9
 
 # Install beets-ytimport from source
 COPY dist /plugin/dist

--- a/beetsplug/ytimport/__init__.py
+++ b/beetsplug/ytimport/__init__.py
@@ -6,13 +6,19 @@ import requests
 from beets.plugins import BeetsPlugin
 from beets.dbcore import types
 from beets.ui import Subcommand
-from beets.ui import _store_dict
-from beets.ui.commands import import_files
 from beets import config
 from optparse import OptionParser
 from confuse import ConfigSource, load_yaml
 import beetsplug.ytimport.youtube
 import beetsplug.ytimport.split
+
+# Beets 2.x have this at the first path, 1.x has it at the path in the `except` branch
+try: 
+    from beets.ui.commands.import_ import _store_dict, import_files
+except ImportError:
+    from beets.ui import _store_dict
+    from beets.ui.commands import import_files
+
 
 class YtImportPlugin(BeetsPlugin):
     item_types = {


### PR DESCRIPTION
I wanted to use this with my beets install, but I'm on a version of beets 2(2.12.0 specifically) which breaks this plugin(an earlier version breaks the plugin, this is just what I'm using). Looking at the code, was a very simple fix and this doesn't break compatibility with anything since it falls back to the 1.x code path if the import fails. I defaulted to the beets 2.x path since that's what I'd expect most users to use nowadays, but there really shouldn't be an impact to performance with beets 1.x

~~I wasn't able to test the e2e tests due to yt-dlp errors~~, but I'm confident this works well, since I've used it on my home server(which has a setup that gets around a lot of youtube's bot blocking stuff) and it works perfectly as before.

Edit: With the second commit, I was able to run the e2e tests, and some worked but others require the js runtime, which doesn't exist in the container. I tried several attempts to get the ejs runtime to work, but none worked so I gave up on it. If you want to try, feel free lmao

Closes #8 